### PR TITLE
fix: catch error when streaming request error

### DIFF
--- a/Sources/OpenAIStreamingCompletions/OpenAI+ChatCompletion.swift
+++ b/Sources/OpenAIStreamingCompletions/OpenAI+ChatCompletion.swift
@@ -133,7 +133,7 @@ extension OpenAIAPI {
     }
     
     private func createChatRequest(completionRequest: ChatCompletionRequest) throws -> URLRequest {
-        let url = URL(string: "https://api.openai.com/v1/chat/completions")!
+        let url = URL(string: "\(self.origin)/v1/chat/completions")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/Sources/OpenAIStreamingCompletions/OpenAI+TextCompletion.swift
+++ b/Sources/OpenAIStreamingCompletions/OpenAI+TextCompletion.swift
@@ -74,7 +74,7 @@ extension OpenAIAPI {
     }
 
     private func createTextRequest(completionRequest: CompletionRequest) throws -> URLRequest {
-        let url = URL(string: "https://api.openai.com/v1/completions")!
+        let url = URL(string: "\(self.origin)/v1/completions")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/Sources/OpenAIStreamingCompletions/OpenAI.swift
+++ b/Sources/OpenAIStreamingCompletions/OpenAI.swift
@@ -3,10 +3,14 @@ import Foundation
 public struct OpenAIAPI {
     var apiKey: String
     var orgId: String?
+    var origin = "https://api.openai.com"
 
-    public init(apiKey: String, orgId: String? = nil) {
+    public init(apiKey: String, orgId: String? = nil, origin: String? = nil) {
         self.apiKey = apiKey
         self.orgId = orgId
+        if let origin = origin {
+            self.origin = origin
+        }
     }
 }
 


### PR DESCRIPTION
Xcode throws the following error when the network connection is unstable.
However, SwiftUI does not capture error properly. ( still .complete )

Still want to be able to throw errors when the network connection is down.
<img width="619" alt="image" src="https://user-images.githubusercontent.com/41619339/226690653-8e9e6e9b-9908-4dcb-a916-05185d5049d7.png">
