### PR TITLE
feat: support custom hostname

### DIFF
--- a/Sources/OpenAIStreamingCompletions/OpenAI+ChatCompletion.swift
+++ b/Sources/OpenAIStreamingCompletions/OpenAI+ChatCompletion.swift
@@ -128,7 +128,7 @@ extension OpenAIAPI {
     }
     
     private func createChatRequest(completionRequest: ChatCompletionRequest) throws -> URLRequest {
-        let url = URL(string: "https://api.openai.com/v1/chat/completions")!
+        let url = URL(string: "https://\(self.host)/v1/chat/completions")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/Sources/OpenAIStreamingCompletions/OpenAI+TextCompletion.swift
+++ b/Sources/OpenAIStreamingCompletions/OpenAI+TextCompletion.swift
@@ -74,7 +74,7 @@ extension OpenAIAPI {
     }
 
     private func createTextRequest(completionRequest: CompletionRequest) throws -> URLRequest {
-        let url = URL(string: "https://api.openai.com/v1/completions")!
+        let url = URL(string: "https://\(self.host)/v1/completions")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/Sources/OpenAIStreamingCompletions/OpenAI.swift
+++ b/Sources/OpenAIStreamingCompletions/OpenAI.swift
@@ -8,7 +8,9 @@ public struct OpenAIAPI {
     public init(apiKey: String, host: String? = nil, orgId: String? = nil) {
         self.apiKey = apiKey
         if let host = host {
-            self.host = host
+            if host.isValidDomain() {
+                self.host = host
+            }
         }
         self.orgId = orgId
     }
@@ -22,3 +24,16 @@ extension OpenAIAPI {
     }
 }
 
+extension String {
+    func isValidDomain() -> Bool {
+        let regex = try! NSRegularExpression(pattern: "^(?=.{1,255}$)(?!\\\\d+$)[a-z0-9-]+(\\.[a-z0-9-]+)*$", options: .caseInsensitive)
+        let range = NSRange(location: 0, length: count)
+        var domain = self
+        if hasPrefix("https://") {
+            domain = String(dropFirst(8))
+        }
+        let isDomainValid = regex.firstMatch(in: domain, options: [], range: range) != nil
+        
+        return isDomainValid
+    }
+}

--- a/Sources/OpenAIStreamingCompletions/OpenAI.swift
+++ b/Sources/OpenAIStreamingCompletions/OpenAI.swift
@@ -2,10 +2,14 @@ import Foundation
 
 public struct OpenAIAPI {
     var apiKey: String
+    var host: String = "api.openai.com"
     var orgId: String?
 
-    public init(apiKey: String, orgId: String? = nil) {
+    public init(apiKey: String, host: String? = nil, orgId: String? = nil) {
         self.apiKey = apiKey
+        if let host = host {
+            self.host = host
+        }
         self.orgId = orgId
     }
 }

--- a/Sources/OpenAIStreamingCompletions/OpenAI.swift
+++ b/Sources/OpenAIStreamingCompletions/OpenAI.swift
@@ -30,7 +30,7 @@ extension String {
         let range = NSRange(location: 0, length: count)
         var domain = self
         if hasPrefix("https://") {
-            domain = String(dropFirst(8))
+            return false
         }
         let isDomainValid = regex.firstMatch(in: domain, options: [], range: range) != nil
         


### PR DESCRIPTION
Some users may require proxy services for accessing the API due to certain restrictions. In order to better support these users, it is necessary to support custom domain name.

**Usage:**

To use the default API domain, use the following code:

```swift
let api = OpenAIAPI(apiKey: key)
// url = URL(string: "https://api.openai.com/v1/completions")!
```

To use a custom domain name, pass the domain hostname as the host parameter while initializing the OpenAIAPI object, as shown below:

```swift
let customAPI = OpenAIAPI(apiKey: key, host: host)
// url = URL(string: "https://\(self.host)/v1/completions")!
```